### PR TITLE
Serialize errors before they are sent through IPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "apollo-link": "^1.2.6",
     "iterall": "^1.2.2",
+    "serialize-error": "^5.0.0",
     "zen-observable-ts": "^0.8.13"
   },
   "devDependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { createAsyncIterator, forAwaitEach, isAsyncIterable } from 'iterall';
 import { getMainDefinition } from 'apollo-utilities';
 import { ApolloLink, FetchResult, Observable, execute as executeLink, Operation } from 'apollo-link';
 import { parse, execute, subscribe, ExecutionArgs } from 'graphql';
+import { serializeError } from 'serialize-error';
 
 const isSubscription = query => {
   const main = getMainDefinition(query);
@@ -58,7 +59,7 @@ export const createIpcExecutor = (options: IpcExecutorOptions) => {
 
     return result.subscribe(
       data => event.sender.send(channel, id, 'data', data),
-      error => event.sender.send(channel, id, 'error', error),
+      error => event.sender.send(channel, id, 'error', serializeError(error)),
       () => event.sender.send(channel, id, 'complete'),
     );
   };


### PR DESCRIPTION
Resolves https://github.com/fubhy/graphql-transport-electron/issues/1

Deserialization on the client is handled by apollo.