### PR TITLE
Prevent unhandled Exception when window is closing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -57,10 +57,18 @@ export const createIpcExecutor = (options: IpcExecutorOptions) => {
       query: parse(request.query),
     });
 
+    const sendIpc = (type, data?) => {
+      try {
+        event.sender.send(channel, id, type, data);
+      } catch {
+        // WebContext has been destroyed, can't send
+      }
+    };
+
     return result.subscribe(
-      data => event.sender.send(channel, id, 'data', data),
-      error => event.sender.send(channel, id, 'error', serializeError(error)),
-      () => event.sender.send(channel, id, 'complete'),
+      data => sendIpc('data', data),
+      error => sendIpc('error', serializeError(error)),
+      () => sendIpc('complete'),
     );
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,10 +58,8 @@ export const createIpcExecutor = (options: IpcExecutorOptions) => {
     });
 
     const sendIpc = (type, data?) => {
-      try {
+      if (!event.sender.isDestroyed()) {
         event.sender.send(channel, id, type, data);
-      } catch {
-        // WebContext has been destroyed, can't send
       }
     };
 


### PR DESCRIPTION
When trying to send a PubSub message and in that moment the window is closed, `graphql-transport-electron` throws unhandled `Object has been destroyed` exception when calling event.sender.send. It's not possible to handle the exception in app code, also in many cases it's not possible to check whether webContents is destroyed or not, because there are a few event loop ticks between calling PubSub.publish and webContents.send. It occurs very frequently when PubSub is used intensively.