### PR TITLE
chore: Make contextSerializer optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import { IpcRenderer, IpcMain } from 'electron';
 export interface ApolloIpcLinkOptions<TContext = any> {
   channel?: string;
   ipc: IpcRenderer;
-  contextSerializer: (context: TContext) => any;
+  contextSerializer?: (context: TContext) => any;
 }
 
 export interface SchemaLinkOptions<TContext = any, TRoot = any> {


### PR DESCRIPTION
Code added by #13 allows this option to be unset